### PR TITLE
Add redo button and count hits

### DIFF
--- a/.godot/editor/Main.tscn-editstate-bcb0d2eb5949c52b6a65bfe9de3e985b.cfg
+++ b/.godot/editor/Main.tscn-editstate-bcb0d2eb5949c52b6a65bfe9de3e985b.cfg
@@ -8,7 +8,7 @@ Anim={
 "grid_snap_active": false,
 "grid_step": Vector2(8, 8),
 "grid_visibility": 1,
-"ofs": Vector2(-187.2, -115.4),
+"ofs": Vector2(-369.582, -260.945),
 "primary_grid_step": Vector2i(8, 8),
 "show_group_gizmos": true,
 "show_guides": true,
@@ -34,7 +34,7 @@ Anim={
 "snap_rotation_step": 0.261799,
 "snap_scale": false,
 "snap_scale_step": 0.1,
-"zoom": 0.25
+"zoom": 0.707107
 }
 3D={
 "fov": 70.01,
@@ -175,4 +175,4 @@ Anim={
 "zfar": 4000.01,
 "znear": 0.05
 }
-selected_nodes=Array[NodePath]([])
+selected_nodes=Array[NodePath]([NodePath("/root/@EditorNode@16894/@Panel@13/@VBoxContainer@14/DockHSplitLeftL/DockHSplitLeftR/DockHSplitMain/@VBoxContainer@25/DockVSplitCenter/@VSplitContainer@52/@VBoxContainer@53/@PanelContainer@98/MainScreen/@CanvasItemEditor@9280/@VSplitContainer@9102/@HSplitContainer@9104/@HSplitContainer@9106/@Control@9107/@SubViewportContainer@9108/@SubViewport@9109/HUD/HitLabel")])

--- a/.godot/editor/editor_layout.cfg
+++ b/.godot/editor/editor_layout.cfg
@@ -10,14 +10,14 @@ dock_split_2=0
 dock_split_3=0
 dock_hsplit_1=0
 dock_hsplit_2=540
-dock_hsplit_3=-540
+dock_hsplit_3=-843
 dock_hsplit_4=0
 dock_filesystem_h_split_offset=480
 dock_filesystem_v_split_offset=0
 dock_filesystem_display_mode=0
 dock_filesystem_file_sort=0
 dock_filesystem_file_list_display_mode=1
-dock_filesystem_selected_paths=PackedStringArray("res://hud.tscn")
+dock_filesystem_selected_paths=PackedStringArray("res://main.gd")
 dock_filesystem_uncollapsed_paths=PackedStringArray("Favorites", "res://")
 dock_3="Scene,Import"
 dock_4="FileSystem"
@@ -26,7 +26,7 @@ dock_5="Inspector,Node,History"
 [EditorNode]
 
 open_scenes=PackedStringArray("res://Main.tscn", "res://Mob.tscn", "res://Player.tscn", "res://hud.tscn")
-current_scene="res://Player.tscn"
+current_scene="res://hud.tscn"
 center_split_offset=0
 selected_default_debugger_tab_idx=0
 selected_main_editor_idx=2
@@ -34,10 +34,10 @@ selected_bottom_panel_item=0
 
 [ScriptEditor]
 
-open_scripts=["res://export_presets.cfg", "res://hud.gd", "res://player.gd"]
-selected_script="res://player.gd"
-open_help=["Input"]
-script_split_offset=140
+open_scripts=["res://export_presets.cfg", "res://hud.gd", "res://main.gd", "res://mob.gd", "res://player.gd"]
+selected_script="res://main.gd"
+open_help=[]
+script_split_offset=460
 list_split_offset=0
 zoom_factor=1.0
 

--- a/.godot/editor/project_metadata.cfg
+++ b/.godot/editor/project_metadata.cfg
@@ -1,18 +1,24 @@
 [editor_metadata]
 
 executable_path="/Applications/Godot.app/Contents/MacOS/Godot"
+use_advanced_connections=false
 
 [recent_files]
 
 scenes=["res://hud.tscn", "res://Player.tscn", "res://Mob.tscn", "res://Main.tscn"]
-scripts=["Input", "res://player.gd", "res://hud.gd", "res://export_presets.cfg"]
+scripts=["Signal", "CanvasLayer", "CollisionShape2D", "res://mob.gd", "res://main.gd", "Input", "res://player.gd", "res://hud.gd", "res://export_presets.cfg"]
 
 [dialog_bounds]
 
 export=Rect2(356, 744, 2520, 1794)
-editor_settings=Rect2(0, 106, 2560, 2660)
+editor_settings=Rect2(634, 364, 2560, 2660)
 project_settings=Rect2(838, 742, 2400, 1400)
+create_new_node=Rect2(1660, 740, 1800, 1400)
 
 [export_options]
 
 default_filename="gdot-creep"
+
+[script_setup]
+
+last_selected_language="GDScript"

--- a/.godot/editor/script_editor_cache.cfg
+++ b/.godot/editor/script_editor_cache.cfg
@@ -17,11 +17,11 @@ state={
 state={
 "bookmarks": PackedInt32Array(),
 "breakpoints": PackedInt32Array(),
-"column": 0,
+"column": 27,
 "folded_lines": Array[int]([]),
 "h_scroll_position": 0,
-"row": 0,
-"scroll_position": 0.0,
+"row": 38,
+"scroll_position": 11.0,
 "selection": false,
 "syntax_highlighter": "GDScript"
 }
@@ -31,11 +31,43 @@ state={
 state={
 "bookmarks": PackedInt32Array(),
 "breakpoints": PackedInt32Array(),
-"column": 20,
+"column": 13,
 "folded_lines": Array[int]([]),
 "h_scroll_position": 0,
-"row": 31,
-"scroll_position": 11.0,
+"row": 49,
+"scroll_position": 27.0,
+"selection": false,
+"syntax_highlighter": "GDScript"
+}
+
+[res://main.gd]
+
+state={
+"bookmarks": PackedInt32Array(),
+"breakpoints": PackedInt32Array(),
+"column": 1,
+"folded_lines": Array[int]([]),
+"h_scroll_position": 0,
+"row": 32,
+"scroll_position": 0.12,
+"selection": true,
+"selection_from_column": 1,
+"selection_from_line": 32,
+"selection_to_column": 23,
+"selection_to_line": 32,
+"syntax_highlighter": "GDScript"
+}
+
+[res://mob.gd]
+
+state={
+"bookmarks": PackedInt32Array(),
+"breakpoints": PackedInt32Array(),
+"column": 0,
+"folded_lines": Array[int]([]),
+"h_scroll_position": 0,
+"row": 15,
+"scroll_position": 0.0,
 "selection": false,
 "syntax_highlighter": "GDScript"
 }

--- a/Main.tscn
+++ b/Main.tscn
@@ -61,8 +61,9 @@ stream = SubResource("AudioStreamOggVorbis_vdjtb")
 [node name="DeathSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("5_fbye1")
 
-[connection signal="hit" from="Player" to="." method="game_over"]
+[connection signal="hit" from="Player" to="." method="update_hit_counter"]
 [connection signal="timeout" from="MobTimer" to="." method="_on_mob_timer_timeout"]
 [connection signal="timeout" from="ScoreTimer" to="." method="_on_score_timer_timeout"]
 [connection signal="timeout" from="StartTimer" to="." method="_on_start_timer_timeout"]
+[connection signal="redo_game" from="HUD" to="." method="_on_hud_redo_game"]
 [connection signal="start_game" from="HUD" to="." method="new_game"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,3 +17,13 @@ Example of my beautiful project! xD
 
 ### Android
 - https://docs.godotengine.org/en/stable/tutorials/export/exporting_for_android.html
+- Pay closer attention to the versions listed for the sdk pkgs 
+- Open GoDot via this terminal command: (I wonder if it gives admin privoleges?)
+  - open /Applications/Godot.app
+  - Suggestions from here: https://www.reddit.com/r/godot/comments/1204d2u/apksigner_failed_to_execute_warning_when/ 
+
+Java SDk Path
+- /Users/melissacrawford/Documents/GoDot_reqs/jdk-17.0.13+11/Contents/Home/
+
+Android SDK Path
+- /Users/melissacrawford/Library/Android/sdk/

--- a/hud.gd
+++ b/hud.gd
@@ -2,6 +2,7 @@ extends CanvasLayer
 
 # Notifies 'Main' node that the button has been pressed
 signal start_game
+signal redo_game
 
 
 # Called when the node enters the scene tree for the first time.
@@ -32,7 +33,10 @@ func show_game_over():
 	
 func update_score(score):
 	$ScoreLabel.text = str(score)
-
+	
+func update_hits(hits):
+	var text = "Hits: %s" % hits
+	$HitLabel.text = str(text)
 
 func _on_start_button_pressed() -> void:
 	$StartButton.hide()
@@ -41,3 +45,7 @@ func _on_start_button_pressed() -> void:
 
 func _on_message_timer_timeout() -> void:
 	$Message.hide()
+
+
+func _on_redo_button_button_up() -> void:
+	redo_game.emit()

--- a/hud.tscn
+++ b/hud.tscn
@@ -68,5 +68,30 @@ text = "Start
 wait_time = 2.0
 one_shot = true
 
+[node name="RedoButton" type="Button" parent="."]
+offset_left = 367.0
+offset_top = 13.0
+offset_right = 462.0
+offset_bottom = 60.0
+theme_override_fonts/font = ExtResource("1_dwead")
+theme_override_font_sizes/font_size = 32
+text = "Redo"
+
+[node name="HitLabel" type="Label" parent="."]
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -237.0
+offset_top = 4.0
+offset_right = -135.0
+offset_bottom = 48.0
+grow_horizontal = 2
+theme_override_fonts/font = ExtResource("1_dwead")
+theme_override_font_sizes/font_size = 20
+text = "Hits 0"
+horizontal_alignment = 1
+vertical_alignment = 1
+
 [connection signal="pressed" from="StartButton" to="." method="_on_start_button_pressed"]
 [connection signal="timeout" from="MessageTimer" to="." method="_on_message_timer_timeout"]
+[connection signal="button_up" from="RedoButton" to="." method="_on_redo_button_button_up"]

--- a/main.gd
+++ b/main.gd
@@ -2,6 +2,7 @@ extends Node
 
 @export var mob_scene: PackedScene
 var score
+var hits
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -24,10 +25,12 @@ func game_over() -> void:
 	
 func new_game():
 	score = 0
+	hits = 0
 	$Player.start($StartPosition.position)
 	$StartTimer.start()
 	
 	$HUD.update_score(score)
+	$HUD.update_hits(hits)
 	$HUD.show_message("Get Ready")
 	get_tree().call_group("mobs", "queue_free")
 	
@@ -71,4 +74,22 @@ func _on_mob_timer_timeout() -> void:
 	add_child(mob)
 	
 	
+	
+	
+func update_hit_counter():
+	hits += 1
+	$HUD.update_hits(hits)
+
+func _on_hud_redo_game() -> void:
+	$Player.hide_player()
+	#score = 0
+	#$HUD.update_score(score)
+	#
+	#hits = 0
+	#$HUD.update_hits(hits)
+	
+	game_over()
+	
+	# Free all mobs
+	get_tree().call_group("mobs", "queue_free")
 	

--- a/player.gd
+++ b/player.gd
@@ -45,13 +45,17 @@ func _process(delta: float) -> void:
 	position = position.clamp(Vector2.ZERO, screen_size)	
 		
 	
-
-
 func _on_body_entered(body: Node2D) -> void:
-	hide() # Player disappears after being hit
 	hit.emit()
+	#$MAIN.update_hit_counter()
+	
+	
+func hide_player():
+	hide() # Player disappears after being hit
+	#hit.emit()
 	# Must be deferred as we can't change physics properties on a physics callback.
 	$CollisionShape2D.set_deferred("disabled", true)
+	
 	
 func start(pos):
 	position = pos


### PR DESCRIPTION
I wanted to play with the current setup.

- Add a "redo" button instead of re-starting the game when the player gets hit
- Added a "hits" label to show how many times the player ran into a creep. (Wanted to maintain functionality of something happening when you touch player)